### PR TITLE
[CREATED] 로그인을 위한 유저 존재여부 확인 뷰 및 로그인 뷰

### DIFF
--- a/users/urls.py
+++ b/users/urls.py
@@ -1,5 +1,8 @@
 from django.urls import path
 
-urlpatterns = [
+from users.views import UserCheckView, SigninView
 
+urlpatterns = [
+    path('signin', SigninView.as_view()),
+    path('check', UserCheckView.as_view()),
 ]

--- a/users/urls.py
+++ b/users/urls.py
@@ -1,8 +1,7 @@
 from django.urls import path
 
-from users.views import UserCheckView, SigninView
+from users.views import SigninView
 
 urlpatterns = [
     path('signin', SigninView.as_view()),
-    path('check', UserCheckView.as_view()),
 ]

--- a/users/views.py
+++ b/users/views.py
@@ -6,44 +6,8 @@ from django.http            import JsonResponse
 from django.core.exceptions import ValidationError
 
 from users.models     import User
-from shops.models     import Cart
 from users.validators import UserValidator
 from my_settings      import SECRET_KEY, ALGORITHM
-
-class UserCheckView(View):
-    def post(self, request):
-        try:
-            data  = json.loads(request.body)
-
-            email = data['email']
-
-            UserValidator().validate_email(email)
-
-            name = User.objects.get(email=email).name
-
-            name = name[0] + '*'*(len(name)-1)
-
-            result = {
-                'email': email,
-                'name' : name
-            }
-
-            return JsonResponse({'MESSAGE': 'SUCCESS', 'RESULT': result}, status=200)
-
-        except json.decoder.JSONDecodeError:
-            return JsonResponse({'MESSAGE': 'BODY_REQUIRED'}, status=400)
-
-        except KeyError:
-            return JsonResponse({'MESSAGE': 'KEY_ERROR'}, status=400)
-
-        except ValidationError as e:
-            return JsonResponse({'MESSAGE': e.message}, status=400)
-
-        except User.DoesNotExist:
-            result = {
-                'email': email
-            }
-            return JsonResponse({'MESSAGE': 'USER_NOT_FOUND', 'RESULT': result}, status=400)
 
 
 class SigninView(View):
@@ -55,43 +19,15 @@ class SigninView(View):
             password        = data['password']
 
             user            = User.objects.get(email=email)
-            user_id         = user.id
             hashed_password = user.password.encode('utf-8')
 
             if not bcrypt.checkpw(password.encode('utf-8'), hashed_password):
                 return JsonResponse({'MESSAGE': 'LOGIN_FAILED'}, status=400)
 
-            payload   = {
-                'id': user_id
-            }
+            payload   = {'id': user.id}
             token     = jwt.encode(payload, SECRET_KEY, ALGORITHM)
 
-            cart_list = Cart.objects.filter(
-                user__id=user_id
-            ).select_related(
-                'product__category',
-                'product'
-            ).prefetch_related(
-                'product__image_set',
-                'product__tags'
-            )
-
-            results = [
-                {
-                    'product_id'    : cart_item.product.id,
-                    'category_name' : cart_item.product.category.name,
-                    'tags'          : list(map(
-                        lambda x: x[0], cart_item.product.tags.values_list('name')
-                    )),
-                    'ml_volume'     : cart_item.product.category.ml_volume,
-                    'price'         : cart_item.product.category.price,
-                    'amount'        : cart_item.amount,
-                    'thumb'         : cart_item.product.image_set.get(name='thumb').url
-                }
-                for cart_item in cart_list
-            ]
-
-            return JsonResponse({'MESSAGE': 'SUCCESS', 'TOKEN': token, 'RESULT': results}, status=200)
+            return JsonResponse({'MESSAGE': 'SUCCESS', 'TOKEN': token}, status=200)
 
         except json.decoder.JSONDecodeError:
             return JsonResponse({'MESSAGE': 'BODY_REQUIRED'}, status=400)

--- a/users/views.py
+++ b/users/views.py
@@ -1,3 +1,103 @@
-from django.shortcuts import render
+import json
 
-# Create your views here.
+import jwt, bcrypt
+from django.views           import View
+from django.http            import JsonResponse
+from django.core.exceptions import ValidationError
+
+from users.models     import User
+from shops.models     import Cart
+from users.validators import UserValidator
+from my_settings      import SECRET_KEY, ALGORITHM
+
+class UserCheckView(View):
+    def post(self, request):
+        try:
+            data  = json.loads(request.body)
+
+            email = data['email']
+
+            UserValidator().validate_email(email)
+
+            name = User.objects.get(email=email).name
+
+            name = name[0] + '*'*(len(name)-1)
+
+            result = {
+                'email': email,
+                'name' : name
+            }
+
+            return JsonResponse({'MESSAGE': 'SUCCESS', 'RESULT': result}, status=200)
+
+        except json.decoder.JSONDecodeError:
+            return JsonResponse({'MESSAGE': 'BODY_REQUIRED'}, status=400)
+
+        except KeyError:
+            return JsonResponse({'MESSAGE': 'KEY_ERROR'}, status=400)
+
+        except ValidationError as e:
+            return JsonResponse({'MESSAGE': e.message}, status=400)
+
+        except User.DoesNotExist:
+            return JsonResponse({'MESSAGE': 'USER_NOT_FOUND'}, status=400)
+
+
+class SigninView(View):
+    def post(self, request):
+        try:
+            data            = json.loads(request.body)
+
+            email           = data['email']
+            password        = data['password']
+
+            user            = User.objects.get(email=email)
+            user_id         = user.id
+            hashed_password = user.password.encode('utf-8')
+
+            if not bcrypt.checkpw(password.encode('utf-8'), hashed_password):
+                return JsonResponse({'MESSAGE': 'LOGIN_FAILED'}, status=400)
+
+            payload   = {
+                'id': user_id
+            }
+            token     = jwt.encode(payload, SECRET_KEY, ALGORITHM)
+
+            cart_list = Cart.objects.filter(
+                user__id=user_id
+            ).select_related(
+                'product__category',
+                'product'
+            ).prefetch_related(
+                'product__image_set',
+                'product__tags'
+            )
+
+            results = [
+                {
+                    'product_id'    : cart_item.product.id,
+                    'category_name' : cart_item.product.category.name,
+                    'tags'          : list(map(
+                        lambda x: x[0], cart_item.product.tags.values_list('name')
+                    )),
+                    'ml_volume'     : cart_item.product.category.ml_volume,
+                    'price'         : cart_item.product.category.price,
+                    'amount'        : cart_item.amount,
+                    'thumb'         : cart_item.product.image_set.get(name='thumb').url
+                }
+                for cart_item in cart_list
+            ]
+
+            return JsonResponse({'MESSAGE': 'SUCCESS', 'TOKEN': token, 'RESULT': result}, status=200)
+
+        except json.decoder.JSONDecodeError:
+            return JsonResponse({'MESSAGE': 'BODY_REQUIRED'}, status=400)
+
+        except KeyError:
+            return JsonResponse({'MESSAGE': 'KEY_ERROR'}, status=400)
+
+        except User.DoesNotExist:
+            return JsonResponse({'MESSAGE': 'LOGIN_FAILED'}, status=400)
+
+        except AttributeError:
+            return JsonResponse({'MESSAGE': 'LOGIN_FAILED'}, status=400)

--- a/users/views.py
+++ b/users/views.py
@@ -40,7 +40,10 @@ class UserCheckView(View):
             return JsonResponse({'MESSAGE': e.message}, status=400)
 
         except User.DoesNotExist:
-            return JsonResponse({'MESSAGE': 'USER_NOT_FOUND'}, status=400)
+            result = {
+                'email': email
+            }
+            return JsonResponse({'MESSAGE': 'USER_NOT_FOUND', 'RESULT': result}, status=400)
 
 
 class SigninView(View):

--- a/users/views.py
+++ b/users/views.py
@@ -88,7 +88,7 @@ class SigninView(View):
                 for cart_item in cart_list
             ]
 
-            return JsonResponse({'MESSAGE': 'SUCCESS', 'TOKEN': token, 'RESULT': result}, status=200)
+            return JsonResponse({'MESSAGE': 'SUCCESS', 'TOKEN': token, 'RESULT': results}, status=200)
 
         except json.decoder.JSONDecodeError:
             return JsonResponse({'MESSAGE': 'BODY_REQUIRED'}, status=400)


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 와이즐리만의 특색있는 로그인/회원가입 페이지를 위한 유저 존재 여부 확인 기능 구현
- 아이디, 비밀번호를 사용한 로그인 기능 구현

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 로그인 전 유저 정보 확인
- 로그인 전 이메일을 입력 후 post로 이메일을 보내면 그 이메일이 validate한지, 그 유저가 존재하는지 확인
- 유저가 존재한다면 다시 왔던 이메일 정보와, 이름의 첫 글자를 제외하고 모자이크 된 이름 정보를 return
- validate하지만 유저가 존재하지 않는다면 USER_NOT_FOUND 메시지를 보내 회원가입 페이지로 연결되도록 진행(들어왔던 이메일 정보 리턴)

2. 로그인
- 이메일, 비밀번호 입력받아 유저 존재 여부 / 로그인 기능 구현
- 유저가 존재하고 비밀번호가 일치해 로그인이 성공하면 SUCCESS메시지, 유저 정보(id)를 담은 jwt, 유저가 장바구니에 담아 두었던 상품들에 대한 정보를 리턴

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 처음 보는 신기한 로그인/회원가입 페이지로 인해 처음 시도해보는 형태의 로그인 뷰를 구현해볼 수 있었습니다.
- 유저가 로그인하면 장바구니에 담긴 제품들에 대한 정보를 반환해줘야 하기 때문에 참조/역참조에 대해 다양한 방법으로 활용해 볼 수 있었습니다.
- 여러 에러들에 대해 핸들링 해볼 수 있었습니다.

<br />

## :: 기타 질문 및 특이 사항
- 장바구니 관련된 로직이 약간 긴 것 같아 더욱 효율적인 방법이 있나 궁금합니다.