### PR TITLE
[CREATED] CartView의 delete 메소드 추가

### DIFF
--- a/shops/urls.py
+++ b/shops/urls.py
@@ -3,5 +3,8 @@ from django.urls import path
 from shops.views import CartView
 
 urlpatterns = [
-    path('/carts', CartView.as_view()),
+    path('/carts', include([
+        path('', CartView.as_view()),
+        path('/<int:product_id>', CartView.as_view())
+    ])),
 ]

--- a/shops/views.py
+++ b/shops/views.py
@@ -11,7 +11,7 @@ from core.utils       import authorization
 
 class CartView(View):
     @authorization
-    def get(self, request):
+    def get(self, request, **kwargs):
         user = request.user
 
         cart_list = Cart.objects.filter(
@@ -46,9 +46,9 @@ class CartView(View):
         return JsonResponse({'MESSAGE': 'SUCCESS', 'RESULT': results}, status=200)
 
     @authorization
-    def delete(self, request):
+    def delete(self, request, **kwargs):
         try:
-            product_id = request.GET['product_id']
+            product_id = kwargs['product_id']
             user       = request.user
 
             cart_item  = Cart.objects.get(user=user, product_id=product_id)

--- a/shops/views.py
+++ b/shops/views.py
@@ -44,3 +44,23 @@ class CartView(View):
         ]
 
         return JsonResponse({'MESSAGE': 'SUCCESS', 'RESULT': results}, status=200)
+
+    @authorization
+    def delete(self, request):
+        try:
+            product_id = request.GET['product_id']
+            user       = request.user
+
+            cart_item  = Cart.objects.get(user=user, product_id=product_id)
+            cart_item.delete()
+
+            return JsonResponse({'MESSAGE': 'DELETED'}, status=200)
+
+        except KeyError:
+            return JsonResponse({'MESSAGE': 'PARAM_REQUIRED'}, status=400)
+
+        except Cart.DoesNotExist:
+            return JsonResponse({'MESSAGE': 'INVALID_PRODUCT'}, status=400)
+
+        except ValueError:
+            return JsonResponse({'MESSAGE': 'INVALID_PRODUCT'}, status=400)


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 장바구니에서 제품을 제거하기 위한 delete 메소드 구현

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
- delete 메소드 요청 시 query parameter로 삭제할 제품의 아이디 값 전송
- 파라미터에 product_id가 존재하는지 확인한 후 유저의 장바구니에 그 제품이 담겨있는지 확인
- 제품이 담겨있다면 Cart 테이블에서 현재 유저와 삭제하고자 하는 제품을 참조하는 row 삭제

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- request.GET을 사용해서 body에 담기는 내용이 아닌 query parameter에 담겨 넘어오는 값을 핸들링 해 볼 수 있었습니다.

<br />

## :: 기타 질문 및 특이 사항
- delete 메소드의 경우 payload를 가질 수 없다고 알고 있습니다. 그럴 경우 이런 식으로 query parameter를 이용해 filter 하고자 하는 정보를 넘겨줘도 괜찮은지 잘 모르겠습니다.