### PR TITLE
[CREATED] 주문 정보를 조회하기 위한 get 메소드 구현(all/specifig)

### DIFF
--- a/shops/urls.py
+++ b/shops/urls.py
@@ -1,10 +1,14 @@
 from django.urls import path, include
 
-from shops.views import CartView
+from shops.views import CartView, AllOrderView, OrderView
 
 urlpatterns = [
     path('/carts', include([
         path('', CartView.as_view()),
         path('/<int:product_id>', CartView.as_view())
+    ])),
+    path('/orders', include([
+        path('/all', AllOrderView.as_view()),
+        path('/<int:order_id>', OrderView.as_view())
     ])),
 ]

--- a/shops/views.py
+++ b/shops/views.py
@@ -1,12 +1,12 @@
-import json
+import json, datetime
 
 from django.views           import View
 from django.http            import JsonResponse
-from django.db.models       import Prefetch
+from django.db.models       import Prefetch, Count
 from django.core.exceptions import ValidationError
 from django.db              import IntegrityError
 
-from shops.models           import Cart
+from shops.models           import Cart, Order
 from products.models        import Image, Product
 from core.utils             import authorization
 from shops.validators       import ShopValidator
@@ -114,3 +114,91 @@ class CartView(View):
 
         except Cart.DoesNotExist:
             return JsonResponse({'MESSAGE': 'INVALID_PRODUCT'}, status=400)
+
+
+class AllOrderView(View):
+    @authorization
+    def get(self, request):
+        user   = request.user
+
+        orders = Order.objects.filter(user=user).select_related(
+            'order_status'
+        ).prefetch_related(
+            'orderitem_set',
+            Prefetch(
+                'orderitem_set__product__image_set',
+                queryset = Image.objects.filter(name='thumb'),
+                to_attr  = 'thumb'
+            ),
+            'orderitem_set__product__category'
+         ).annotate(order_items_count=Count('orderitem'))
+
+        results = [
+            {
+                'order_id'          : order.id,
+                'order_status'      : order.order_status.status,
+                'ordered_at'        : datetime.datetime.date(order.created_at),
+                'thumb'             : order.orderitem_set.all()[0].product.thumb[0].url,
+                'order_number'      : order.order_number,
+                'order_items_count' : order.order_items_count,
+                'category_name'     : order.orderitem_set.all()[0].product.category.name,
+            }
+            for order in orders
+        ]
+
+        return JsonResponse({'MESSAGE': 'SUCCESS', 'RESULT': results}, status=200)
+
+
+class OrderView(View):
+    @authorization
+    def get(self, request, **kwargs):
+        try:
+            user     = request.user
+
+            order_id = kwargs['order_id']
+
+            order    = Order.objects.select_related(
+                'address'
+            ).prefetch_related(
+                'orderitem_set',
+                'orderitem_set__product',
+                'orderitem_set__product__category',
+                'orderitem_set__product__tags',
+                Prefetch(
+                    'orderitem_set__product__image_set',
+                    queryset = Image.objects.filter(name='thumb'),
+                    to_attr  = 'thumb'
+                )
+            ).get(id=order_id, user=user)
+
+            results = {
+                'name'        : user.name,
+                'address'     : order.address.location\
+                    if order.address else '배송지 정보가 없습니다.',
+                'phone'       : user.phone,
+                'order_items' : [
+                    {
+                        'category_name'     : order_item.product.category.name,
+                        'amount'            : order_item.amount,
+                        'ml_volume'         : order_item.product.category.ml_volume,
+                        'thumb'             : order_item.product.thumb[0].url,
+                        'tags'              : [
+                            tag.name
+                            for tag in order_item.product.tags.all()
+                        ],
+                        'order_item_status' : order_item.order_item_status.status,
+                        'shipping_company'  : order_item.shipping_company.name\
+                            if order_item.shipping_company else '배송 업체 정보가 없습니다.',
+                        'shipping_number'   : order_item.shipping_number
+                    }
+                    for order_item in order.orderitem_set.all()
+                ]
+            }
+
+            return JsonResponse({'MESSAGE': 'SUCCESS', 'RESULT': results}, status=200)
+
+        except KeyError:
+            return JsonResponse({'MESSAGE': 'KEY_ERROR'}, status=400)
+
+        except Order.DoesNotExist:
+            return JsonResponse({'MESSAGE': 'INVALID_ORDER'}, status=400)

--- a/shops/views.py
+++ b/shops/views.py
@@ -11,6 +11,7 @@ from products.models        import Image, Product
 from core.utils             import authorization
 from shops.validators       import ShopValidator
 
+
 class CartView(View):
     @authorization
     def get(self, request, **kwargs):

--- a/shops/views.py
+++ b/shops/views.py
@@ -144,7 +144,7 @@ class CartView(View):
 
         except KeyError:
             return JsonResponse({'MESSAGE': 'KEY_ERROR'}, status=400)
-          
+
         except Cart.DoesNotExist:
             return JsonResponse({'MESSAGE': 'INVALID_CART'}, status=400)
 
@@ -153,8 +153,8 @@ class CartView(View):
 
         except ValidationError as e:
             return JsonResponse({'MESSAGE': e.message}, status=400)
-          
-          
+
+
 class AllOrderView(View):
     @authorization
     def get(self, request):
@@ -212,8 +212,7 @@ class OrderView(View):
 
             results = {
                 'name'        : user.name,
-                'address'     : order.address.location\
-                    if order.address else '배송지 정보가 없습니다.',
+                'address'     : order.address.location if order.address else '배송지 정보가 없습니다.',
                 'phone'       : user.phone,
                 'order_items' : [
                     {
@@ -221,13 +220,9 @@ class OrderView(View):
                         'amount'            : order_item.amount,
                         'ml_volume'         : order_item.product.category.ml_volume,
                         'thumb'             : order_item.product.thumb[0].url,
-                        'tags'              : [
-                            tag.name
-                            for tag in order_item.product.tags.all()
-                        ],
+                        'tags'              : [tag.name for tag in order_item.product.tags.all()],
                         'order_item_status' : order_item.order_item_status.status,
-                        'shipping_company'  : order_item.shipping_company.name\
-                            if order_item.shipping_company else '배송 업체 정보가 없습니다.',
+                        'shipping_company'  : order_item.shipping_company.name if order_item.shipping_company else '배송 업체 정보가 없습니다.',
                         'shipping_number'   : order_item.shipping_number
                     }
                     for order_item in order.orderitem_set.all()
@@ -235,9 +230,9 @@ class OrderView(View):
             }
 
             return JsonResponse({'MESSAGE': 'SUCCESS', 'RESULT': results}, status=200)
-          
+
         except KeyError:
             return JsonResponse({'MESSAGE': 'KEY_ERROR'}, status=400)
-          
+
         except Order.DoesNotExist:
             return JsonResponse({'MESSAGE': 'INVALID_ORDER'}, status=400)


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 주문 정보를 조회하기 위한 get 메소드 구현

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 전체 주문 정보 조회
- 특정 유저의 모든 주문 내역 조회 get 메소드 구현
- 각 주문의 order_item들 중 첫번째([0]) order_item의 썸네일, 카테고리 이름을 주문 내역의 대표 이미지로 하여 ~~외 N개 와 같이 표기하기 위해 총 상품 개수 반환(annotate와 Count활용)
- created_at(TimeStampModel)을 통해 주문을 한 날짜를 반환 -> datetime.datetime.date(created_at)과 같은 방식 사용
- 더미 데이터의 경우 bcrypt.gensalt()를 utf-8로 디코딩해 order_number로 사용(랜덤값을 구하기 위함)

2. 특정 주문 정보 조회
- url param을 통해 특정 주문 내역 id를 요청받아 상세 주문 내역 반환
- 배송지 정보, 배송 업체 정보는 null=True(models.SET_NULL)이기에 존재하는지 여부에 따라 '배송지 정보가 없습니다.', '배송 업체 정보가 없습니다.' 등으로 핸들링
- 유저 정보, order_id로 동시에 조회해서 현재 유저의 주문 내역이 아닌데 노출되지 않도록 구현
- shipping_number의 경우 blank=True로 blank or not blank일때 둘 다 반환해줌(프론트에서 핸들링)

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- Count, Prefetch, annotate 등을 사용해 코드를 줄이거나 쿼리의 수를 줄이는 방법에 대해 생각해 볼 수 있었습니다.
- prefetch_related를 진행하고 .filter, .all이 아닌 .get, .values 등을 사용하면 prefetch하는 의미가 없다는 사실에 대해 알게 되었습니다.

<br />

## :: 기타 질문 및 특이 사항